### PR TITLE
Move materialize alerts out to their own files

### DIFF
--- a/app/assets/javascripts/flash.js
+++ b/app/assets/javascripts/flash.js
@@ -1,0 +1,8 @@
+$('document').ready(function(){
+  var flashInfo = $('.flash').first();
+  if(flashInfo.length) {
+    var type = flashInfo.data('type');
+    var message = flashInfo.data('message');
+    Materialize.toast(message, 3000, 'alert ' + type);
+  }
+});

--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,3 +1,7 @@
+.flash {
+  display: none;
+}
+
 .alert.success {
   @extend .green, .darken-4;
 }

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,8 @@
+<% flash.each do |type, message| %>
+  <% type = 'success' if type == 'notice' %>
+  <div class="flash flash-<%= type %>"
+       data-type="<%= type %>"
+       data-message="<%= message %>">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,17 +8,7 @@
 </head>
 <body>
 
-  <% flash.each do |type, message| %>
-    <% type = 'success' if type == 'notice' %>
-    <%= content_tag :div, class: 'flash_data', data: { type: type, message: message} do %>
-    <% end %>
-    <script>
-      var info = $('.flash_data');
-      var type = info.data('type');
-      var message = info.data('message');
-      Materialize.toast(message, 3000, 'alert ' + type);
-    </script>
-  <% end %>
+  <%= render 'layouts/flash' %>
 
   <div class="container">
     <%= yield %>


### PR DESCRIPTION
Refactor materialize alerts to get the script tags out. Alerts now run in their own file and check for any flash messages placed by rails on document.ready.