### PR TITLE
Redirect to previous url after token failure

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,20 +1,44 @@
 class ApiController < ApplicationController
   protect_from_forgery with: :null_session
 
-  rescue_from Errors::TokenExpired, with: :token_error
+  before_action :set_current_url
+
+  rescue_from Errors::TokenExpired, with: :handle_token_error
+  rescue_from Errors::MissingToken, with: :handle_missing_token
 
   protected
 
-  def token_error
-    service = 'Google'
-    provider = 'google_oauth2'
-    if params[:controller].include?('microsoft')
-      service = 'Microsoft'
-      provider = 'microsoft_office365'
-    end
+  def set_current_url
+    current_url = params[:current_url] || request.path
+    store_location_for(:user, current_url)
+  end
+
+  def handle_token_error
+    get_service
+
     render json: {
-      message: "Your link to #{service} has expired. Please authorize again.",
-      provider: provider
+      message: "Your link to #{@service} has expired. Please authorize again.",
+      provider: @provider
     }, status: :unauthorized
+  end
+
+  def handle_missing_token
+    get_service
+
+    render json: {
+      message: "You have not linked your account to #{@service}. "\
+               "Redirecting you to do so now.",
+      provider: @provider
+    }, status: :unauthorized
+  end
+
+  def get_service
+    @service = 'Google'
+    @provider = 'google_oauth2'
+
+    if params[:controller].include?('microsoft')
+      @service = 'Microsoft'
+      @provider = 'microsoft_office365'
+    end
   end
 end

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -3,7 +3,6 @@ class IdentitiesController < ApplicationController
     Identity.find_or_create_from_omniauth(request.env['omniauth.auth'],
                                           current_user)
 
-
-    redirect_to (stored_location_for(:user) || advisees_path)
+    redirect_to stored_location_for(:user) || advisees_path
   end
 end

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -3,6 +3,7 @@ class IdentitiesController < ApplicationController
     Identity.find_or_create_from_omniauth(request.env['omniauth.auth'],
                                           current_user)
 
-    redirect_to advisees_path
+
+    redirect_to (stored_location_for(:user) || advisees_path)
   end
 end

--- a/react/src/components/ExportMeeting.js
+++ b/react/src/components/ExportMeeting.js
@@ -30,7 +30,8 @@ class ExportMeeting extends Component {
       method: 'POST',
       data: {
         calendar: calendar,
-        notify: notify
+        notify: notify,
+        current_url: this.props.currentUrl
       }
     })
     .done((data) => {
@@ -57,7 +58,10 @@ class ExportMeeting extends Component {
   getCalendars() {
     $.ajax({
       url: this.baseUrl,
-      method: 'GET'
+      method: 'GET',
+      data: {
+        current_url: this.props.currentUrl
+      }
     })
     .done((data) => {
       ReactDOM.render(

--- a/react/src/components/ExportOptions.js
+++ b/react/src/components/ExportOptions.js
@@ -26,6 +26,8 @@ class ExportOptions extends Component {
         <ul id={id} className='dropdown-content'>
           <li>
             <ExportMeeting meeting={this.props.meeting} accountType="Google" />
+          </li>
+          <li>
             <ExportMeeting meeting={this.props.meeting} accountType="Microsoft" />
           </li>
         </ul>

--- a/react/src/components/ExportOptions.js
+++ b/react/src/components/ExportOptions.js
@@ -25,10 +25,14 @@ class ExportOptions extends Component {
 
         <ul id={id} className='dropdown-content'>
           <li>
-            <ExportMeeting meeting={this.props.meeting} accountType="Google" />
+            <ExportMeeting meeting={this.props.meeting}
+                           currentUrl={this.props.currentUrl}
+                           accountType="Google" />
           </li>
           <li>
-            <ExportMeeting meeting={this.props.meeting} accountType="Microsoft" />
+            <ExportMeeting meeting={this.props.meeting}
+                           currentUrl={this.props.currentUrl}
+                           accountType="Microsoft" />
           </li>
         </ul>
       </div>

--- a/react/src/components/Meeting.js
+++ b/react/src/components/Meeting.js
@@ -55,6 +55,11 @@ class Meeting extends Component {
     let meetingDescription = 'Meeting';
     let meetingUrl = `/meetings/${meeting.id}`;
 
+    let currentUrl = this.props.currentUrl;
+    if(!currentUrl){
+      currentUrl = `/advisees/${meeting.advisee_id}`;
+    }
+
     if(meeting.description && meeting.description.length){
       meetingDescription = meeting.description;
     }
@@ -81,7 +86,8 @@ class Meeting extends Component {
                   onClick={this.handleDelete}>
             <i className="material-icons">delete</i>
           </button>
-          <ExportOptions meeting={this.props.meeting} />
+          <ExportOptions meeting={this.props.meeting}
+                         currentUrl={currentUrl} />
         </div>
       </div>
     );

--- a/react/src/components/UpcomingMeetings.js
+++ b/react/src/components/UpcomingMeetings.js
@@ -52,7 +52,8 @@ class UpcomingMeetings extends Component {
       return meetings.map((meeting) => {
         return <Meeting key={meeting.id}
                         meeting={meeting}
-                        advisee={meeting.advisee} />
+                        advisee={meeting.advisee}
+                        currentUrl="/advisees" />
       });
     }
   }

--- a/spec/controllers/google_calendars_controller_spec.rb
+++ b/spec/controllers/google_calendars_controller_spec.rb
@@ -9,9 +9,13 @@ describe Api::V1::GoogleCalendarsController, type: :controller do
 
   describe 'GET /api/v1/google_calendars' do
     it 'raises an error if there is no token' do
-      expect do
-        get :index
-      end.to raise_error(Errors::MissingToken)
+      get :index
+
+      json = parse_json(response, :unauthorized)
+
+      expect(json['message']).to include('You have not linked your account to '\
+                                         'Google. Redirecting you')
+      expect(json['provider']).to eq('google_oauth2')
     end
 
     it 'raises an error if the token is expired' do

--- a/spec/controllers/microsoft_calendars_controller_spec.rb
+++ b/spec/controllers/microsoft_calendars_controller_spec.rb
@@ -9,9 +9,13 @@ describe Api::V1::MicrosoftCalendarsController, type: :controller do
 
   describe 'GET /api/v1/microsoft_calendars' do
     it 'raises an error if there is no token' do
-      expect do
-        get :index
-      end.to raise_error(Errors::MissingToken)
+      get :index
+
+      json = parse_json(response, :unauthorized)
+
+      expect(json['message']).to include('You have not linked your account to '\
+                                         'Microsoft. Redirecting you')
+      expect(json['provider']).to eq('microsoft_office365')
     end
 
     it 'raises an error if the token is expired' do


### PR DESCRIPTION
Sets the current_url on every API request. After a token error, it will use that to redirect appropriately.